### PR TITLE
Remove deprecated classes for Twig 1.12

### DIFF
--- a/Twig/Extension/FormExtension.php
+++ b/Twig/Extension/FormExtension.php
@@ -30,8 +30,8 @@ class FormExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'form_js' => new \Twig_Function_Method($this, 'renderJavascript', array('is_safe' => array('html'))),
-            'form_css' => new \Twig_Function_Node('Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', array('is_safe' => array('html'))),
+            'form_js' => new \Twig_SimpleFunction('form_js', array($this, 'renderJavascript'), array('is_safe' => array('html'))),
+            'form_css' => new \Twig_SimpleFunction('form_css', null, array('node_class' => 'Symfony\Bridge\Twig\Node\SearchAndRenderBlockNode', 'is_safe' => array('html'))),
         );
     }
 
@@ -41,8 +41,8 @@ class FormExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            'e4js'      => new \Twig_Filter_Method($this, 'escape_for_js'),
-            'nowrap'    => new \Twig_Filter_Method($this, 'nowrap'),
+            'e4js'      => new \Twig_SimpleFilter('e4js', array($this, 'escape_for_js')),
+            'nowrap'    => new \Twig_SimpleFilter('nowrap', array($this, 'nowrap')),
         );
     }
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "symfony/symfony": ">= 2.2.0",
-        "twig/twig": ">= 1.9.0",
+        "twig/twig": ">= 1.12.0",
         "twig/extensions": "~1.0"
     },
     "suggest": {


### PR DESCRIPTION
The `Twig_Filter_Method`, `Twig_Function_Node` and `Twig_Function_Method` classes have been deprecated in favor of the `Twig_SimpleFilter` and `Twig_SimpleFunction` classes.
This PR fixes that for this repo.